### PR TITLE
check if "docker compose" or "docker-compose" should be used

### DIFF
--- a/src/project.py
+++ b/src/project.py
@@ -179,11 +179,12 @@ class Project:
         # Run docker-compose
         try:
             with open(self.source_directory / self.name / "logs.txt", "w") as output_log:
+                docker_compose_bin = ["docker-compose"] if shutil.which("docker-compose") else ["docker", "compose"]
                 docker_pull = subprocess.Popen(
-                    ["docker", "compose", "pull"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
+                    [*docker_compose_bin, "pull"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
                     )
                 docker_process = subprocess.Popen(
-                    ["docker", "compose", "up"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
+                    [*docker_compose_bin, "up"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
                     )
         except subprocess.CalledProcessError as e:
             print(Fore.RED + f"An error occurred: {e}")

--- a/src/project.py
+++ b/src/project.py
@@ -329,8 +329,9 @@ class Project:
         # Run docker-compose
         try:
             with open(self.source_directory / self.name / "logs.txt", "a") as output_log:
+                docker_compose_bin = ["docker-compose"] if shutil.which("docker-compose") else ["docker", "compose"]
                 docker_process = subprocess.Popen(
-                    ["docker", "compose", "down"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
+                    [*docker_compose_bin, "down"], cwd=self.source_directory / self.name, text=True, stdout=output_log, stderr=output_log
                     )
         except subprocess.CalledProcessError as e:
             print(Fore.RED + f"An error occurred: {e}")


### PR DESCRIPTION
Check of existence of `docker-compose` (default on debian) to prevent this:
![image](https://github.com/user-attachments/assets/24efa9ad-5d25-4559-ac78-31d1a8dfb3fe)
